### PR TITLE
Fix service worker asset paths

### DIFF
--- a/gene/service-worker.js
+++ b/gene/service-worker.js
@@ -1,11 +1,11 @@
 const CACHE_NAME = 'gene-cache-v1';
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/service-worker.js',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png'
+  './',
+  './index.html',
+  './manifest.json',
+  './service-worker.js',
+  './icons/192x192.png',
+  './icons/512x512.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- use relative asset paths in the Gene service worker
- update icon filenames

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68484de539108329bbbb4595e7b99158