### PR TITLE
Fix duplicated <p> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
                         <a href="./gol/" tabindex="-1">
                             <div>
                                 <h2>Conway's Game of Life</h2>
-                                <p><p><b>Conway's Game of Life:</b> A cellular automaton where cells live/die based on neighbor counts (2-3 to survive, 3 to be born).<br/><b>Features:</b> Play/Pause/Step/Reset, Pattern Selector, Wrapped/Infinite Modes, Speed Control, Pan & Zoom (Slider/Mousewheel/Pinch), Click-to-Draw, Save/Restore Grid, Population/Step Counters, Responsive Design, & Colorful Cell Aging.</p></p>
+                                <p><b>Conway's Game of Life:</b> A cellular automaton where cells live/die based on neighbor counts (2-3 to survive, 3 to be born).<br/><b>Features:</b> Play/Pause/Step/Reset, Pattern Selector, Wrapped/Infinite Modes, Speed Control, Pan & Zoom (Slider/Mousewheel/Pinch), Click-to-Draw, Save/Restore Grid, Population/Step Counters, Responsive Design, & Colorful Cell Aging.</p>
                             </div>
                         </a>
                     </td>
@@ -173,7 +173,7 @@
                         <a href="./pendulum/" tabindex="-1">
                             <div>
                                 <h2>Double Pendulum</h2>
-                                <p><p><b>Double Pendulum Simulator:</b> Explore chaotic motion with this interactive double pendulum simulator (v0.7). Adjust the lengths, masses, and starting angles of the pendulum bobs. Customize the simulation's background and the pendulum/trace color; the interface, including sliders with large themed knobs, dynamically adapts to your choices. Watch the physics-based simulation in real-time, see the trace path, and download it as an image. This PWA is installable and offers basic offline use.</p></p>
+                                <p><b>Double Pendulum Simulator:</b> Explore chaotic motion with this interactive double pendulum simulator (v0.7). Adjust the lengths, masses, and starting angles of the pendulum bobs. Customize the simulation's background and the pendulum/trace color; the interface, including sliders with large themed knobs, dynamically adapts to your choices. Watch the physics-based simulation in real-time, see the trace path, and download it as an image. This PWA is installable and offers basic offline use.</p>
                             </div>
                         </a>
                     </td>
@@ -188,7 +188,7 @@
                         <a href="./spiro/" tabindex="-1">
                             <div>
                                 <h2>SpiroGen</h2>
-                                <p><p><b>SpiroGen v2.2:</b> Create art with up to 4 nodes, pan/zoom, persistent traces, Node 1 fixed mode & starting angle, PWA support, Memory, and PNG download.</p></p>
+                                <p><b>SpiroGen v2.2:</b> Create art with up to 4 nodes, pan/zoom, persistent traces, Node 1 fixed mode & starting angle, PWA support, Memory, and PNG download.</p>
                             </div>
                         </a>
                     </td>


### PR DESCRIPTION
## Summary
- fix double `<p>` tags in Game of Life, Double Pendulum and SpiroGen rows

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848505fae6c8329a13d55ece38e7b55