### PR TITLE
Fix service worker for blob/data URL audio

### DIFF
--- a/btc/sw.js
+++ b/btc/sw.js
@@ -33,6 +33,13 @@ self.addEventListener('install', event => {
 self.addEventListener('fetch', event => {
     const requestUrl = new URL(event.request.url);
 
+    // Let the browser handle data: and blob: URLs. Intercepting them can cause
+    // failed fetches ("Load failed") in some browsers like iOS Safari.
+    if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
+        // console.log('Service Worker: Bypassing', requestUrl.protocol, 'request:', event.request.url);
+        return;
+    }
+
     // For API calls to LiveCoinWatch and Google's Generative Language API,
     // always go to the network. These are typically POST requests or dynamic
     // content that shouldn't be served from a simple cache.

--- a/btc/test/sw.js
+++ b/btc/test/sw.js
@@ -33,11 +33,12 @@ self.addEventListener('install', event => {
 self.addEventListener('fetch', event => {
     const requestUrl = new URL(event.request.url);
 
-    // If the request is for a data: URL, do not attempt to handle it with the service worker.
-    // to let the browser handle them directly.
-    if (requestUrl.protocol === 'data:') {
-        // console.log('Service Worker: Bypassing data: request:', event.request.url);
-        return; // Let the browser handle it directly without calling event.respondWith()
+    // If the request is for a data: or blob: URL, let the browser handle it
+    // directly without interfering. Attempting to fetch these via the network
+    // results in "Load failed" errors on some browsers (e.g., iOS Safari).
+    if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
+        // console.log('Service Worker: Bypassing', requestUrl.protocol, 'request:', event.request.url);
+        return; // Do not call event.respondWith
     }
 
     // For API calls to LiveCoinWatch and Google's Generative Language API,


### PR DESCRIPTION
## Summary
- update service workers to ignore `data:` and `blob:` URLs so object URLs are not intercepted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848743035748329a3132568ece65466