### PR TITLE
Fix service worker intercept error

### DIFF
--- a/btc/sw.js
+++ b/btc/sw.js
@@ -40,11 +40,12 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // Let the browser handle data: and blob: URLs directly. On some browsers
-    // attempting to handle these in the service worker triggers
-    // "FetchEvent.respondWith received an error" log messages.
+    // Let the browser handle data: and blob: URLs directly. Attempting to
+    // respond to these from the service worker with fetch() can result in
+    // "FetchEvent.respondWith received an error" messages, so we simply do not
+    // intercept them.
     if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
-        event.respondWith(fetch(event.request));
+        console.log('Service Worker: bypassing data/blob URL', event.request.url);
         return;
     }
 

--- a/btc/test/sw.js
+++ b/btc/test/sw.js
@@ -40,11 +40,12 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // If the request is for a data: or blob: URL, bypass any custom caching and
-    // allow the browser to fetch it normally. Some browsers otherwise log
-    // "FetchEvent.respondWith received an error" when these are intercepted.
+    // If the request is for a data: or blob: URL, let the browser handle it
+    // entirely. Calling fetch() on these schemes from a service worker results
+    // in "FetchEvent.respondWith received an error" log messages in some
+    // browsers, so we simply avoid intercepting them at all.
     if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
-        event.respondWith(fetch(event.request));
+        console.log('Service Worker: bypassing data/blob URL', event.request.url);
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid intercepting data/blob URLs in service workers
- log bypassed requests for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68488871029c8329a76da29ab5a6fd0e