### PR TITLE
Fix audio fetch errors in service worker

### DIFF
--- a/btc/sw.js
+++ b/btc/sw.js
@@ -44,7 +44,21 @@ self.addEventListener('fetch', event => {
     // "FetchEvent.respondWith received an error" messages, so we simply do not
     // intercept them.
     if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
+        // Use fetch() explicitly for data/blob URLs to avoid
+        // "FetchEvent.respondWith received an error" log messages
+        // that occur if we simply return without a response.
         console.log('Service Worker: bypassing data/blob URL', event.request.url);
+        event.respondWith(
+            fetch(event.request)
+                .then(response => {
+                    console.log('Service Worker: fetched data/blob URL successfully');
+                    return response;
+                })
+                .catch(error => {
+                    console.error('Service Worker: failed to fetch data/blob URL', error);
+                    return Response.error();
+                })
+        );
         return;
     }
 

--- a/btc/test/sw.js
+++ b/btc/test/sw.js
@@ -44,7 +44,21 @@ self.addEventListener('fetch', event => {
     // in "FetchEvent.respondWith received an error" log messages in some
     // browsers, so we simply avoid intercepting them at all.
     if (requestUrl.protocol === 'data:' || requestUrl.protocol === 'blob:') {
+        // Explicitly respond with fetch() so browsers do not
+        // log "FetchEvent.respondWith received an error" when
+        // handling local data/blob URLs used for audio playback.
         console.log('Service Worker: bypassing data/blob URL', event.request.url);
+        event.respondWith(
+            fetch(event.request)
+                .then(response => {
+                    console.log('Service Worker: fetched data/blob URL successfully');
+                    return response;
+                })
+                .catch(error => {
+                    console.error('Service Worker: failed to fetch data/blob URL', error);
+                    return Response.error();
+                })
+        );
         return;
     }
 


### PR DESCRIPTION
## Summary
- handle `data:` and `blob:` URLs in service workers with `fetch()`
- log success or failure when fetching these URLs to aid debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ed052a74832985fb311b4002b46f