### PR TITLE
Fix service worker fetch error

### DIFF
--- a/btc/sw.js
+++ b/btc/sw.js
@@ -53,13 +53,12 @@ self.addEventListener('fetch', event => {
     }
 
     // For API calls to LiveCoinWatch and Google's Generative Language API,
-    // always go to the network. These are typically POST requests or dynamic
-    // content that shouldn't be served from a simple cache.
+    // bypass the service worker entirely. These requests are dynamic and
+    // letting the browser handle them avoids "FetchEvent.respondWith received an
+    // error" messages if the network request fails.
     if (requestUrl.hostname === 'api.livecoinwatch.com' ||
         requestUrl.hostname === 'generativelanguage.googleapis.com') {
-        // Pass the request directly to the network
-        // console.log('Service Worker: Fetching from network (API call):', event.request.url);
-        event.respondWith(fetch(event.request));
+        // Simply return so the request goes directly to the network.
         return;
     }
 

--- a/btc/swv1.2.js
+++ b/btc/swv1.2.js
@@ -43,11 +43,10 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // For API calls, always go to the network.
-    // For LiveCoinWatch, their API is POST only for these endpoints,
-    // which are typically not cached by service workers by default for GET.
+    // For API calls, bypass the service worker entirely. These requests are
+    // dynamic and should go straight to the network to avoid service worker
+    // errors if the fetch fails.
     if (requestUrl.hostname === 'api.livecoinwatch.com') {
-        event.respondWith(fetch(event.request));
         return;
     }
 

--- a/btc/test/sw.js
+++ b/btc/test/sw.js
@@ -53,13 +53,11 @@ self.addEventListener('fetch', event => {
     }
 
     // For API calls to LiveCoinWatch and Google's Generative Language API,
-    // always go to the network. These are typically POST requests or dynamic
-    // content that shouldn't be served from a simple cache.
+    // bypass the service worker entirely. These are dynamic requests and
+    // avoiding interception prevents errors if the network fetch fails.
     if (requestUrl.hostname === 'api.livecoinwatch.com' ||
         requestUrl.hostname === 'generativelanguage.googleapis.com') {
-        // Pass the request directly to the network
-        // console.log('Service Worker: Fetching from network (API call):', event.request.url);
-        event.respondWith(fetch(event.request));
+        // Simply return so the browser handles the network fetch directly.
         return;
     }
 


### PR DESCRIPTION
## Summary
- bypass service worker for API requests so Safari iOS doesn't log `FetchEvent.respondWith` errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848f293b9948329a0e82045dab9757e