### PR TITLE
Update debug page title and toggle text

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Webpage Wrapper & Debugger</title>
+    <title>Kreft.us Debug</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -406,7 +406,7 @@
         toggleLogDrawerButton.addEventListener('click', () => {
             isLogDrawerOpen = !isLogDrawerOpen;
             document.body.classList.toggle('log-drawer-open', isLogDrawerOpen);
-            toggleLogDrawerButton.textContent = isLogDrawerOpen ? 'Collapse Log' : 'Expand Log';
+            toggleLogDrawerButton.textContent = isLogDrawerOpen ? 'Collapse' : 'Expand';
 
             if (isLogDrawerOpen) {
                 const targetHeight = customExpandedHeight ? customExpandedHeight : (window.innerHeight * DEFAULT_EXPANDED_HEIGHT_VH / 100) + 'px';


### PR DESCRIPTION
## Summary
- rename the page title to `Kreft.us Debug`
- shorten the expand/collapse button text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f941258c8329b95e38d086f27b78